### PR TITLE
refactor(nvim): use harpoon quick menu

### DIFF
--- a/config/nvim/lua/maps/harpoon_maps.lua
+++ b/config/nvim/lua/maps/harpoon_maps.lua
@@ -1,5 +1,14 @@
 local harpoon = require("harpoon")
 
+-- Open harpoon quick menu
+vim.keymap.set(
+    "n",
+    "<C-q>",
+    function ()
+        harpoon.ui:toggle_quick_menu(harpoon:list())
+    end
+)
+
 -- Harpoon the current file
 vim.keymap.set(
     "n",

--- a/config/nvim/lua/maps/telescope_maps.lua
+++ b/config/nvim/lua/maps/telescope_maps.lua
@@ -20,5 +20,3 @@ vim.keymap.set("n", "<leader>fh", telescope_builtin.help_tags)
 vim.keymap.set("n", "<leader>gr", telescope_builtin.lsp_references)
 -- Show symbols in the document using LSP
 vim.keymap.set("n", "<leader>fd", telescope_builtin.lsp_document_symbols)
--- Open harpoon marks
-vim.keymap.set("n", "<C-q>", telescope.extensions.harpoon.marks)

--- a/config/nvim/lua/plugins.lua
+++ b/config/nvim/lua/plugins.lua
@@ -91,6 +91,7 @@ return require("lazy").setup({
         },
         config = function ()
             require("telescope").load_extension("harpoon")
+            require("harpoon"):setup()
         end
     },
 })


### PR DESCRIPTION
Use harpoon quick menu for listing marks instead of telescope finder.