### PR TITLE
feat(nixos): add `gnumake` home module

### DIFF
--- a/config/nixos/hosts/mercury/users/ryan.nix
+++ b/config/nixos/hosts/mercury/users/ryan.nix
@@ -182,5 +182,6 @@ in {
             enableSshSupport = true;
             sshKeys = [ "0D47736C1BD42CF5C821483D6AC6A336578B0964" ];
         };
+        buildTools.gnumake.enable = true;
     };
 }

--- a/config/nixos/modules/home/default.nix
+++ b/config/nixos/modules/home/default.nix
@@ -3,6 +3,7 @@
         ./languages
         ./alacritty.nix
         ./fonts.nix
+        ./gnumake.nix
         ./gpg.nix
         ./libreoffice.nix
         ./neovim.nix

--- a/config/nixos/modules/home/gnumake.nix
+++ b/config/nixos/modules/home/gnumake.nix
@@ -1,0 +1,12 @@
+{ config, lib, pkgs, ... }:
+let
+    cfg = config.sys.buildTools.gnumake;
+in {
+    options = {
+        sys.buildTools.gnumake.enable = lib.mkEnableOption "Enable GNU Make";
+    };
+
+    config = lib.mkIf cfg.enable {
+        home.packages = with pkgs; [ gnumake ];
+    };
+}


### PR DESCRIPTION
Adds `gnumake` home manager module and enables it for mercury.