### PR TITLE
refactor(nixos): remove pointer acceleration command from sway config

### DIFF
--- a/config/nixos/hosts/mercury/users/ryan.nix
+++ b/config/nixos/hosts/mercury/users/ryan.nix
@@ -28,7 +28,6 @@ let
         # Change the mouse sensitivity
         input 1133:49291:Logitech_G502_HERO_Gaming_Mouse {
             accel_profile flat
-            pointer_accel -0.9
         }
 
         #


### PR DESCRIPTION
Removes pointer acceleration command from NixOS Sway config.