### PR TITLE
refactor(nixos): remove `webcord` from mercury

### DIFF
--- a/config/nixos/hosts/mercury/users/gaming.nix
+++ b/config/nixos/hosts/mercury/users/gaming.nix
@@ -9,7 +9,7 @@
     home.username = "gaming";
     home.homeDirectory = "/home/gaming";
 
-    home.packages = with pkgs; [ steam webcord ];
+    home.packages = with pkgs; [ steam ];
 
     sys = {
         shell.zsh.enable = true;


### PR DESCRIPTION
Removes `webcord` package from mercury due to an Electron EOL error.