### PR TITLE
fix(nixos): add `nct6687d` kernel module for temperature sensing

### DIFF
--- a/config/nixos/hosts/mercury/configuration.nix
+++ b/config/nixos/hosts/mercury/configuration.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
     imports = [
@@ -105,4 +105,7 @@
         xdg-utils
         nautilus
     ];
+
+    # https://wiki.archlinux.org/title/Lm_sensors#MAG_B650_TOMAHAWK_WIFI_(MS-7D75)/MAG_B550_MORTAR_WIFI_(MS-7C94)
+    boot.extraModulePackages = with config.boot.kernelPackages; [ nct6687d ];
 }

--- a/config/waybar/config
+++ b/config/waybar/config
@@ -1,3 +1,4 @@
+// vim: filetype=jsonc
 {
     "layer": "top", // Waybar at top layer
     "position": "bottom", // Waybar position (top|bottom|left|right)


### PR DESCRIPTION
Adds the `nct6687d` kernel module for reporting correct temperatures.