### PR TITLE
refactor(nvim): update diagnostic config

### DIFF
--- a/config/nvim/lua/configs/lsp_config.lua
+++ b/config/nvim/lua/configs/lsp_config.lua
@@ -90,7 +90,7 @@ cmp.setup {
 }
 
 -- Show diagnostic information on the current line.
-vim.diagnostic.config({ virtual_lines = { only_current_line = true } })
+vim.diagnostic.config({ virtual_lines = { current_line = true } })
 
 local orig_util_open_floating_preview = vim.lsp.util.open_floating_preview
 function vim.lsp.util.open_floating_preview(contents, syntax, opts, ...)

--- a/config/nvim/lua/plugins.lua
+++ b/config/nvim/lua/plugins.lua
@@ -108,11 +108,4 @@ return require("lazy").setup({
             require("ibl").setup({ scope = { enabled = false } })
         end
     },
-
-    {
-        url = "https://git.sr.ht/~whynothugo/lsp_lines.nvim",
-        config = function ()
-            require("lsp_lines").setup()
-        end
-    },
 })


### PR DESCRIPTION
* Removes the `lsp_lines.nvim` plugin which is built into nvim 0.11.
* Updates configuration of `virtual_lines` to match the nvim config.