### PR TITLE
refactor(nixos): switch to yazi file manager on mercury

### DIFF
--- a/config/nixos/hosts/mercury/configuration.nix
+++ b/config/nixos/hosts/mercury/configuration.nix
@@ -103,7 +103,6 @@
         git
         librewolf
         xdg-utils
-        nautilus
     ];
 
     # https://wiki.archlinux.org/title/Lm_sensors#MAG_B650_TOMAHAWK_WIFI_(MS-7D75)/MAG_B550_MORTAR_WIFI_(MS-7C94)

--- a/config/nixos/hosts/mercury/users/ryan.nix
+++ b/config/nixos/hosts/mercury/users/ryan.nix
@@ -6,6 +6,8 @@ let
 
         bindsym $mod+m output $secondary_display toggle
 
+        bindsym $mod+y exec $term -e yazi
+
         #
         # ==== Outputs ===
         #
@@ -166,6 +168,7 @@ in {
         };
         scripts.startSwayNvidia.enable = true;
         fonts.nerdfonts.enable = true;
+        fileManagers.yazi.enable = true;
         editor.neovim = {
             enable = true;
             defaultEditor = true;

--- a/config/nixos/modules/home/default.nix
+++ b/config/nixos/modules/home/default.nix
@@ -12,6 +12,7 @@
         ./ssh.nix
         ./sway.nix
         ./tmux.nix
+        ./yazi.nix
         ./zsh.nix
     ];
 }

--- a/config/nixos/modules/home/yazi.nix
+++ b/config/nixos/modules/home/yazi.nix
@@ -1,0 +1,14 @@
+{ config, lib, ... }:
+let
+    cfg = config.sys.fileManagers.yazi;
+in {
+    options = {
+        sys.fileManagers.yazi = {
+            enable = lib.mkEnableOption "Enable yazi file manager";
+        };
+    };
+
+    config = lib.mkIf cfg.enable {
+        programs.yazi.enable = true;
+    };
+}


### PR DESCRIPTION
Removes globally installed `nautilus` file manager and switches over to `yazi` file manager on mercury.