### PR TITLE
refactor(nvim): fix deprecation warning in lsp configuration

### DIFF
--- a/config/nvim/lua/configs/lsp_config.lua
+++ b/config/nvim/lua/configs/lsp_config.lua
@@ -8,7 +8,11 @@ vim.cmd [[autocmd! ColorScheme * highlight FloatBorder guifg=white guibg=#1f2335
 -- after the language server attaches to the current buffer
 local on_attach = function(client, bufnr)
     -- Enable completion triggered by <c-x><c-o>
-    vim.api.nvim_buf_set_option(bufnr, "omnifunc", "v:lua.vim.lsp.omnifunc")
+    vim.api.nvim_set_option_value(
+        "omnifunc",
+        "v:lua.vim.lsp.omnifunc",
+        { buf = bufnr }
+    )
 
     -- Mappings.
     -- See `:help vim.lsp.*` for documentation on any of the below functions


### PR DESCRIPTION
Fixes a deprecation warning with `vim.api.nvim_buf_set_option`.