### PR TITLE
feat(nixos): add modules for `qbittorrent` and `vlc`

### DIFF
--- a/config/nixos/hosts/mercury/users/gaming.nix
+++ b/config/nixos/hosts/mercury/users/gaming.nix
@@ -20,5 +20,7 @@
         };
         messengers.signal.enable = true;
         encryption.gpg.enable = true;
+        media.vlc.enable = true;
+        torrent.qbittorrent.enable = true;
     };
 }

--- a/config/nixos/modules/home/default.nix
+++ b/config/nixos/modules/home/default.nix
@@ -8,10 +8,12 @@
         ./gpg.nix
         ./libreoffice.nix
         ./neovim.nix
+        ./qbittorrent.nix
         ./signal.nix
         ./ssh.nix
         ./sway.nix
         ./tmux.nix
+        ./vlc.nix
         ./yazi.nix
         ./zsh.nix
     ];

--- a/config/nixos/modules/home/qbittorrent.nix
+++ b/config/nixos/modules/home/qbittorrent.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+let
+    cfg = config.sys.torrent.qbittorrent;
+in {
+    options = {
+        sys.torrent.qbittorrent.enable = lib.mkEnableOption "Enables qBittorent";
+    };
+
+    config = lib.mkIf cfg.enable {
+        home.packages = [
+            pkgs.qbittorrent
+        ];
+    };
+}

--- a/config/nixos/modules/home/vlc.nix
+++ b/config/nixos/modules/home/vlc.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+let
+    cfg = config.sys.media.vlc;
+in {
+    options = {
+        sys.media.vlc.enable = lib.mkEnableOption "Enable VLC media player";
+    };
+
+    config = lib.mkIf cfg.enable {
+        home.packages = [
+            pkgs.vlc
+        ];
+    };
+}


### PR DESCRIPTION
Adds modules for `qbittorrent` and `vlc` packages and enables them for gaming user of mercury.