### PR TITLE
feat(nixos): add `ollama` module

### DIFF
--- a/config/nixos/hosts/mercury/users/ryan.nix
+++ b/config/nixos/hosts/mercury/users/ryan.nix
@@ -188,5 +188,6 @@ in {
             sshKeys = [ "0D47736C1BD42CF5C821483D6AC6A336578B0964" ];
         };
         buildTools.gnumake.enable = true;
+        ai.ollama.enable = true;
     };
 }

--- a/config/nixos/modules/home/default.nix
+++ b/config/nixos/modules/home/default.nix
@@ -8,6 +8,7 @@
         ./gpg.nix
         ./libreoffice.nix
         ./neovim.nix
+        ./ollama.nix
         ./qbittorrent.nix
         ./signal.nix
         ./ssh.nix

--- a/config/nixos/modules/home/ollama.nix
+++ b/config/nixos/modules/home/ollama.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+let
+    cfg = config.sys.ai.ollama;
+in {
+    options = {
+        sys.ai.ollama.enable = lib.mkEnableOption "Enable Ollama";
+    };
+
+    config = lib.mkIf cfg.enable {
+        services.ollama.enable = true;
+    };
+}

--- a/config/nixos/modules/nix/nvidia.nix
+++ b/config/nixos/modules/nix/nvidia.nix
@@ -21,5 +21,8 @@ in {
             open = true;
             nvidiaSettings = true;
         };
+
+        # Enables CUDA support
+        nixpkgs.config.cudaSupport = true;
     };
 }


### PR DESCRIPTION
* Adds `ollama` home module and enables it for ryan user of mercury.
* Enables CUDA support in nvidia Nix module for allowing ollama to use GPU acceleration.