### PR TITLE
fix(nvim): call setup function of `nvim-treesitter-context` plugin

### DIFF
--- a/config/nvim/lua/plugins.lua
+++ b/config/nvim/lua/plugins.lua
@@ -10,7 +10,12 @@ return require("lazy").setup({
         end
     },
 
-    "nvim-treesitter/nvim-treesitter-context",
+    {
+        "nvim-treesitter/nvim-treesitter-context",
+        config = function()
+            require("treesitter-context").setup()
+        end
+    },
 
     -- LSP configuration
     "neovim/nvim-lspconfig",


### PR DESCRIPTION
Calls the setup function of `nvim-treesitter-context` plugin to enable treesitter context for all file types.