### PR TITLE
fix(nvim): use foldexpr for setting up folds

### DIFF
--- a/config/nvim/lua/configs/treesitter_config.lua
+++ b/config/nvim/lua/configs/treesitter_config.lua
@@ -21,5 +21,7 @@ vim.api.nvim_create_autocmd("FileType", {
     callback = function()
         vim.treesitter.start()
         vim.wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+        vim.opt.foldmethod = "expr"
+        vim.opt.foldlevel = 99
     end
 })


### PR DESCRIPTION
Set values of `foldexpr` and `foldlevel` to correctly setup folds.