### PR TITLE
fix(nvim): disable treesitter in telescope preview window

### DIFF
--- a/config/nvim/lua/maps/telescope_maps.lua
+++ b/config/nvim/lua/maps/telescope_maps.lua
@@ -1,4 +1,3 @@
-local telescope = require("telescope")
 local telescope_builtin = require("telescope.builtin")
 
 -- Open find file prompt. The finder will include hidden files and
@@ -7,11 +6,7 @@ vim.keymap.set("n", "<leader>ff", function ()
     telescope_builtin.find_files({ hidden = true, no_ignore = true })
 end)
 -- Open live grep prompt
-vim.keymap.set(
-    "n",
-    "<leader>fg",
-    telescope.extensions.live_grep_args.live_grep_args
-)
+vim.keymap.set("n", "<leader>fg", telescope_builtin.live_grep)
 -- Open current buffers
 vim.keymap.set("n", "<leader>fb", telescope_builtin.buffers)
 -- Open help tags

--- a/config/nvim/lua/plugins.lua
+++ b/config/nvim/lua/plugins.lua
@@ -68,10 +68,18 @@ return require("lazy").setup({
         tag = "0.1.8",
         dependencies = {
             "nvim-lua/plenary.nvim",
-            "nvim-telescope/telescope-live-grep-args.nvim",
         },
+        -- HACK: This is done to prevent the breaking changes from
+        -- nvim-treesitter from causing errors in the preview. Remove this when
+        -- telescope supports the re-written version of nvim-treesitter.
         config = function()
-            require("telescope").load_extension("live_grep_args")
+            require("telescope").setup({
+                defaults = {
+                    preview = {
+                        treesitter = false,
+                    },
+                },
+            })
         end
     },
 


### PR DESCRIPTION
* Disables treesitter in telescope preview window which is causing the error from [nvim-telescope/telescope.nvim #3487](https://github.com/nvim-telescope/telescope.nvim/issues/3487).
* Removes `telescope-live-grep-args.nvim` extension.