### PR TITLE
fix(nixos): update librewolf package to binary flavor

### DIFF
--- a/config/nixos/hosts/mercury/configuration.nix
+++ b/config/nixos/hosts/mercury/configuration.nix
@@ -101,7 +101,7 @@
     environment.systemPackages = with pkgs; [
         wget
         git
-        librewolf
+        librewolf-bin
         xdg-utils
     ];
 


### PR DESCRIPTION
Updates the package used for LibreWolf browser to `librewolf-bin`.